### PR TITLE
Implements save operation and adds some specific error types for setting UUID

### DIFF
--- a/datastore.go
+++ b/datastore.go
@@ -68,7 +68,11 @@ func (this Datastore) Load(e entity) error {
 	if !e.HasKey() {
 		e.setKey(e.NewKey(this.Context))
 	}
-	return datastore.Get(this.Context, e.Key(), e)
+	err := datastore.Get(this.Context, e.Key(), e)
+	if err == datastore.ErrNoSuchEntity {
+		return ErrNoSuchEntity
+	}
+	return err
 }
 
 // Delete deletes an entity from datastore

--- a/datastore.go
+++ b/datastore.go
@@ -47,6 +47,14 @@ func (this Datastore) Create(e entity) error {
 	return err
 }
 
+func (this Datastore) Save(e entity) error {
+    if err := this.Load(e); err != nil {
+        return err
+    }
+    _, err := datastore.Put(this.Context, e.Key(), e);
+    return err
+}
+
 // Load loads entity data from datastore
 //
 // In case the entity has no key yet assigned
@@ -60,7 +68,6 @@ func (this Datastore) Load(e entity) error {
 	if !e.HasKey() {
 		e.setKey(e.NewKey(this.Context))
 	}
-
 	return datastore.Get(this.Context, e.Key(), e)
 }
 

--- a/model.go
+++ b/model.go
@@ -2,6 +2,11 @@ package db
 
 import (
 	"appengine/datastore"
+	"errors"
+)
+
+var (
+	ErrInvalidUUID = errors.New("Invalid UUID")
 )
 
 // Model represents a datastore entity
@@ -42,6 +47,9 @@ func (this *Model) UUID() string {
 // Currently the UUID is the encoded datastore key
 func (this *Model) SetUUID(uuid string) error {
 	key, err := datastore.DecodeKey(uuid)
+	if err != nil {
+		return ErrInvalidUUID
+	}
 	this.key = key
 	return err
 }


### PR DESCRIPTION
- Save operation only goes thru in case the entity already exists returning an error otherwise
- Setting UUIDs returns `db.ErrInvalidUUID` in case it fails decoding UUID into a `*datastore.Key`
