### PR TITLE
Rename method `QueryFor` to `From`

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ type Tag struct {
 type Tags []*Tag
 
 func (this Tags) ByOwner(owner string) *db.Query {
-	return db.QueryFor(new(Tag)).Filter("Owner=", owner)
+	return db.From(new(Tag)).Filter("Owner=", owner)
 }
 ```
 

--- a/datastore_test.go
+++ b/datastore_test.go
@@ -18,7 +18,7 @@ type CreditCard struct {
 type CreditCards []*CreditCard
 
 func (this CreditCards) ByOwner(owner string) *db.Query {
-	return db.QueryFor(new(CreditCard)).Filter("Owner=", owner)
+	return db.From(new(CreditCard)).Filter("Owner=", owner)
 }
 
 func TestDatastoreCreate(t *testing.T) {

--- a/query.go
+++ b/query.go
@@ -2,7 +2,7 @@ package db
 
 import "appengine/datastore"
 
-func QueryFor(e entity) *Query {
+func From(e entity) *Query {
 	meta := KeyResolver{}
 	meta.ExtractKindMetadata(e)
 	return &Query{datastore.NewQuery(meta.Kind)}


### PR DESCRIPTION
`From` feels more natural, we're querying `From` an `Entity`.
